### PR TITLE
Bunch of fixes

### DIFF
--- a/app/controllers/main/index.js
+++ b/app/controllers/main/index.js
@@ -5,26 +5,26 @@
 let sealer = require('../../services/sealerService');
 
 exports.sign = function (req, res) {
-    sealer.sign(req.query.url, req.query.width, req.query.height).then(function (file) {
-
-        res.download(file);
-    });
+    sealer.sign(req.query.url, req.query.width, req.query.height)
+        .then(function (file) {
+            res.download(file);
+        });
 
 };
 
 exports.store = function (req, res) {
-    sealer.store(req.query.url, req.query.width, req.query.height).then(function (file) {
-
-        res.download(file);
-    });
+    sealer.store(req.query.url, req.query.width, req.query.height)
+        .then(function (file) {
+            res.sendFile(file);
+        });
 
 };
 
 exports.verify = function (req, res) {
-    sealer.verify(req.file.path).then(function (result) {
-
-        res.json({verified: result});
-    });
+    sealer.verify(req.file.path)
+        .then(function (result) {
+            res.json({verified: result});
+        });
 
 };
 

--- a/config/default.js
+++ b/config/default.js
@@ -97,6 +97,6 @@ config.timeout = 10000;
 
 config.crypto_algorithm = 'RSA-SHA256';
 
-config.working_directory = os.tmpDir() + '/sealer';
+config.working_directory = os.tmpdir() + '/sealer';
 
 module.exports = config;

--- a/config/test.js
+++ b/config/test.js
@@ -97,7 +97,7 @@ config.timeout = 10000;
 
 config.crypto_algorithm = 'RSA-SHA256';
 
-config.working_directory = os.tmpDir() + '/sealer_test';
+config.working_directory = os.tmpdir() + '/sealer_test';
 
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "morgan": "~1.7.0",
     "multer": "^1.2.1",
     "phantom": "^3.2.1",
-    "serve-favicon": "~2.3.0",
-    "phantomjs-prebuilt": "^2.1.7"
+    "phantom-pool": "^1.2.0",
+    "phantomjs-prebuilt": "^2.1.7",
+    "serve-favicon": "~2.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
- Use pool for phantom instances (decrease server response time up to 30%) - now bottleneck is only "target" webpage.
- Respect `height` parameter (via setting parameters for cropping same as viewport dimensions).
- Open screenshot instead of downloading (serve image with proper `Content-Type`).